### PR TITLE
Add +t (sticky bit) to default omero_server_datadir_managedrepo_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ omero_server_datadir_managedrepo: "{{ omero_server_datadir }}/ManagedRepository"
 omero_server_datadir_mode: "u=rwX,g=rX,o=rX"
 
 # Permissions for OMERO ManagedRepository
-omero_server_datadir_managedrepo_mode: "u=rwX,g=srwX,o=rX"
+omero_server_datadir_managedrepo_mode: "u=rwX,g=srwX,o=rX,+t"
 
 # Setup systemd services
 omero_server_systemd_setup: True


### PR DESCRIPTION
After a discussion with @pwalczysko over https://github.com/openmicroscopy/ome-documentation/pull/1873 we realised the current outreach playbook has the `+t` permission on the managed repo: https://github.com/openmicroscopy/prod-playbooks/blob/51ddfa88c52248e2affa4300eb73df488be99efd/training-server.yml#L218

It sounds like this may be a good idea but could do with some input from @rleigh-codelibre @mtbc

Note this requires Ansible 2.4 so travis will fail with `bad symbolic permission for mode: +t`, though we can discuss this change as part of https://trello.com/c/SsE1sGqR/184-in-place-import-doc-is-unclear