### PR TITLE
Install OMERO.server in a virtualenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
 env:
   - SCENARIO=newdep
   - SCENARIO=olddep
+  - SCENARIO=upgradetovenv
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ OMERO.server systemd configuration.
 - `omero_server_systemd_after`: A list of strings with additional service names to appear in systemd unit file "After" statements. Default empty/none.
 - `omero_server_systemd_requires`: A list of strings with additional service names to appear in systemd unit file "Requires" statements. Default empty/none.
 
+- `omero_server_python_addons`: List of additional Python packages to be installed into virtualenv.
+  Alternatively you can install packages into `/opt/omero/server/venv` independently from this role.
 - `omero_server_database_backupdir`: Dump the OMERO database to this directory before upgrading, default empty (disabled)
 
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,13 @@ OMERO.server systemd configuration.
 - `omero_server_systemd_after`: A list of strings with additional service names to appear in systemd unit file "After" statements. Default empty/none.
 - `omero_server_systemd_requires`: A list of strings with additional service names to appear in systemd unit file "Requires" statements. Default empty/none.
 
+Python virtualenv
+- `omero_server_virtualenv`: Use a virtualenv for most OMERO.server dependencies, default `False` but this will change in future
 - `omero_server_python_addons`: List of additional Python packages to be installed into virtualenv.
   Alternatively you can install packages into `/opt/omero/server/venv` independently from this role.
+  Requires `omero_server_virtualenv: True`.
+
+Backups
 - `omero_server_database_backupdir`: Dump the OMERO database to this directory before upgrading, default empty (disabled)
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,9 @@ omero_server_systemd_after: []
 # Services which OMERO server needs to be concurrently running.
 omero_server_systemd_requires: []
 
+# List of additional Python packages to be installed into virtualenv
+omero_server_python_addons: []
+
 # If non-empty dump the OMERO database to this directory before upgrading
 omero_server_database_backupdir: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,10 +75,6 @@ omero_server_database_backupdir: ""
 
 # How to run omero
 omero_server_omero_command: >-
-  {{
-    omero_server_virtualenv | ternary(
-      omero_server_basedir + '/venv/bin/python ', '')
-  }}
   {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero
 
 # Recursively set the owner on the OMERO data directory, use if the directory

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,9 @@ omero_server_release: present
 # Ice version
 omero_server_ice_version: "3.6"
 
+# Use a virtualenv
+omero_server_virtualenv: false
+
 # OMERO database connection parameters
 omero_server_dbhost: localhost
 omero_server_dbuser: omero
@@ -70,6 +73,14 @@ omero_server_database_backupdir: ""
 # Expert users only!
 ######################################################################
 
+# How to run omero
+omero_server_omero_command: >-
+  {{
+    omero_server_virtualenv | ternary(
+      omero_server_basedir + '/venv/bin/python ', '')
+  }}
+  {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero
+
 # Recursively set the owner on the OMERO data directory, use if the directory
 # has been copied with an incorrect owner
 omero_server_datadir_chown: false
@@ -124,6 +135,7 @@ omero_server_omego_options: >
   --sym {{ omero_server_symlink }}
   --ice {{ omero_server_ice_version }}
   --no-start
+  --no-web
   --ignoreconfig
   {{ omero_server_omego_verbosity }}
   {{ omero_server_omego_additional_args }}

--- a/molecule/newdep/molecule.yml
+++ b/molecule/newdep/molecule.yml
@@ -32,6 +32,7 @@ provisioner:
         omero_server_release: latest
         omero_server_python_addons:
           - omero-upload
+        omero_server_virtualenv: true
         postgresql_version: "9.6"
         ice_python_wheel: >-
           https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl

--- a/molecule/newdep/molecule.yml
+++ b/molecule/newdep/molecule.yml
@@ -30,6 +30,8 @@ provisioner:
       omero-server-newdep:
         omero_server_ice_version: "3.6"
         omero_server_release: latest
+        omero_server_python_addons:
+          - omero-upload
         postgresql_version: "9.6"
         ice_python_wheel: >-
           https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl

--- a/molecule/resources/install-novenv.yml
+++ b/molecule/resources/install-novenv.yml
@@ -1,0 +1,53 @@
+---
+- name: Install OMERO 5.4 without a virtualenv
+  hosts: all
+
+  roles:
+
+    - role: ome.postgresql
+      postgresql_install_server: true
+      postgresql_databases:
+        - name: omero
+      postgresql_users:
+        - user: omero
+          password: omero
+          databases: [omero]
+
+    - role: ansible-role-omero-server
+      omero_server_system_managedrepo_group: importer
+      omero_server_config_set:
+        Ice.IPv6: "0"
+      omero_server_virtualenv: false
+      # This will override host_vars (this is checked by the later tasks)
+      omero_server_release: "5.4"
+
+  tasks:
+
+    - name: get OMERO version
+      become: true
+      become_user: omero-server
+      command: /opt/omero/server/OMERO.server/bin/omero version
+      register: oldomero_version
+
+    - name: check that OMERO 5.4 was installed
+      assert:
+        that:
+          - oldomero_version.stdout.startswith('5.4.10-')
+
+    - name: check for presence of server venv
+      stat:
+        path: /opt/omero/server/venv
+      register: oldomero_venv_st
+
+    - name: check server venv does not exist
+      assert:
+        that:
+          - not oldomero_venv_st.stat.exists
+
+    - name: additional config file
+      copy:
+        content: >
+          config set omero.policy.binary_access -- "-read,-write,-image,-plate"
+        dest: /opt/omero/server/config/molecule-additional-config.omero
+      notify:
+        - restart omero-server

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -5,7 +5,8 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = ('/opt/omero/server/venv/bin/python '
+         '/opt/omero/server/OMERO.server/bin/omero')
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 
@@ -27,7 +28,7 @@ def test_omero_root_login(host):
 ])
 def test_omero_server_config(host, key, value):
     with host.sudo('omero-server'):
-        cfg = host.check_output("%s config get %s", OMERO, key)
+        cfg = host.check_output("%s config get %s" % (OMERO, key))
     assert cfg == value
 
 

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -1,35 +1,13 @@
 import os
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
-OMERO = ('/opt/omero/server/venv/bin/python '
-         '/opt/omero/server/OMERO.server/bin/omero')
-OMERO_LOGIN = '-C -s localhost -u root -w omero'
-
 
 def test_service_running_and_enabled(host):
     assert host.service('omero-server').is_running
     assert host.service('omero-server').is_enabled
-
-
-def test_omero_root_login(host):
-    with host.sudo('data-importer'):
-        host.check_output('%s login %s' % (OMERO, OMERO_LOGIN))
-
-
-@pytest.mark.parametrize("key,value", [
-    ('omero.data.dir', '/OMERO'),
-    ('omero.client.ui.tree.type_order',
-     '["screen", "plate", "project", "dataset"]'),
-    ('omero.policy.binary_access', '-read,-write,-image,-plate'),
-])
-def test_omero_server_config(host, key, value):
-    with host.sudo('omero-server'):
-        cfg = host.check_output("%s config get %s" % (OMERO, key))
-    assert cfg == value
 
 
 def test_omero_datadir(host):

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -1,13 +1,34 @@
 import os
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO_LOGIN = '-C -s localhost -u root -w omero'
+
 
 def test_service_running_and_enabled(host):
     assert host.service('omero-server').is_running
     assert host.service('omero-server').is_enabled
+
+
+def test_omero_root_login(host):
+    with host.sudo('data-importer'):
+        host.check_output('%s login %s' % (OMERO, OMERO_LOGIN))
+
+
+@pytest.mark.parametrize("key,value", [
+    ('omero.data.dir', '/OMERO'),
+    ('omero.client.ui.tree.type_order',
+     '["screen", "plate", "project", "dataset"]'),
+    ('omero.policy.binary_access', '-read,-write,-image,-plate'),
+])
+def test_omero_server_config(host, key, value):
+    with host.sudo('omero-server'):
+        cfg = host.check_output("%s config get %s", OMERO, key)
+    assert cfg == value
 
 
 def test_omero_datadir(host):

--- a/molecule/resources/tests/test_import.py
+++ b/molecule/resources/tests/test_import.py
@@ -2,7 +2,8 @@ import os
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-newdep')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
+        'omero-server-newdep,omero-server-upgradetovenv')
 
 OMERO = ('/opt/omero/server/venv/bin/python '
          '/opt/omero/server/OMERO.server/bin/omero')

--- a/molecule/resources/tests/test_import.py
+++ b/molecule/resources/tests/test_import.py
@@ -4,7 +4,8 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-newdep')
 
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = ('/opt/omero/server/venv/bin/python '
+         '/opt/omero/server/OMERO.server/bin/omero')
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 

--- a/molecule/resources/tests/test_import.py
+++ b/molecule/resources/tests/test_import.py
@@ -5,8 +5,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
         'omero-server-newdep,omero-server-upgradetovenv')
 
-OMERO = ('/opt/omero/server/venv/bin/python '
-         '/opt/omero/server/OMERO.server/bin/omero')
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 

--- a/molecule/resources/tests/test_newdep.py
+++ b/molecule/resources/tests/test_newdep.py
@@ -5,7 +5,8 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-newdep')
 
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = ('/opt/omero/server/venv/bin/python '
+         '/opt/omero/server/OMERO.server/bin/omero')
 VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
 
 

--- a/molecule/resources/tests/test_newdep.py
+++ b/molecule/resources/tests/test_newdep.py
@@ -7,8 +7,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
         'omero-server-newdep,omero-server-upgradetovenv')
 
-OMERO = ('/opt/omero/server/venv/bin/python '
-         '/opt/omero/server/OMERO.server/bin/omero')
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
 VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
 
@@ -47,3 +46,10 @@ def test_omero_server_config(host, key, value):
 def test_additional_python(host):
     piplist = host.check_output("/opt/omero/server/venv/bin/pip list")
     assert "omero-upload" in piplist
+
+
+def test_running_in_venv(host):
+    python_procs = host.process.filter(user='omero-server', comm='python')
+    for p in python_procs:
+        f = host.file('/proc/%d/exe' % p.pid)
+        assert f.linked_to('/opt/omero/server/venv/bin/python')

--- a/molecule/resources/tests/test_newdep.py
+++ b/molecule/resources/tests/test_newdep.py
@@ -22,3 +22,8 @@ def test_omero_version(host):
 def test_postgres_version(host):
     ver = host.check_output("psql --version")
     assert ver.startswith('psql (PostgreSQL) 9.6.')
+
+
+def test_additional_python(host):
+    piplist = host.check_output("/opt/omero/server/venv/bin/pip list")
+    assert "omero-upload" in piplist

--- a/molecule/resources/tests/test_newdep.py
+++ b/molecule/resources/tests/test_newdep.py
@@ -1,6 +1,5 @@
 import os
 import re
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
@@ -8,7 +7,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
         'omero-server-newdep,omero-server-upgradetovenv')
 
 OMERO = '/opt/omero/server/OMERO.server/bin/omero'
-OMERO_LOGIN = '-C -s localhost -u root -w omero'
 VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
 
 
@@ -24,23 +22,6 @@ def test_omero_version(host):
 def test_postgres_version(host):
     ver = host.check_output("psql --version")
     assert ver.startswith('psql (PostgreSQL) 9.6.')
-
-
-def test_omero_root_login(host):
-    with host.sudo('data-importer'):
-        host.check_output('%s login %s' % (OMERO, OMERO_LOGIN))
-
-
-@pytest.mark.parametrize("key,value", [
-    ('omero.data.dir', '/OMERO'),
-    ('omero.client.ui.tree.type_order',
-     '["screen", "plate", "project", "dataset"]'),
-    ('omero.policy.binary_access', '-read,-write,-image,-plate'),
-])
-def test_omero_server_config(host, key, value):
-    with host.sudo('omero-server'):
-        cfg = host.check_output("%s config get %s" % (OMERO, key))
-    assert cfg == value
 
 
 def test_additional_python(host):

--- a/molecule/resources/tests/test_newdep.py
+++ b/molecule/resources/tests/test_newdep.py
@@ -1,12 +1,15 @@
 import os
 import re
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
-    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-newdep')
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts(
+        'omero-server-newdep,omero-server-upgradetovenv')
 
 OMERO = ('/opt/omero/server/venv/bin/python '
          '/opt/omero/server/OMERO.server/bin/omero')
+OMERO_LOGIN = '-C -s localhost -u root -w omero'
 VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
 
 
@@ -22,6 +25,23 @@ def test_omero_version(host):
 def test_postgres_version(host):
     ver = host.check_output("psql --version")
     assert ver.startswith('psql (PostgreSQL) 9.6.')
+
+
+def test_omero_root_login(host):
+    with host.sudo('data-importer'):
+        host.check_output('%s login %s' % (OMERO, OMERO_LOGIN))
+
+
+@pytest.mark.parametrize("key,value", [
+    ('omero.data.dir', '/OMERO'),
+    ('omero.client.ui.tree.type_order',
+     '["screen", "plate", "project", "dataset"]'),
+    ('omero.policy.binary_access', '-read,-write,-image,-plate'),
+])
+def test_omero_server_config(host, key, value):
+    with host.sudo('omero-server'):
+        cfg = host.check_output("%s config get %s" % (OMERO, key))
+    assert cfg == value
 
 
 def test_additional_python(host):

--- a/molecule/resources/tests/test_olddep.py
+++ b/molecule/resources/tests/test_olddep.py
@@ -5,7 +5,8 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-olddep')
 
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = ('/opt/omero/server/venv/bin/python '
+         '/opt/omero/server/OMERO.server/bin/omero')
 
 
 def test_omero_version(host):

--- a/molecule/resources/tests/test_olddep.py
+++ b/molecule/resources/tests/test_olddep.py
@@ -1,12 +1,13 @@
 import os
 import re
+import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-olddep')
 
-OMERO = ('/opt/omero/server/venv/bin/python '
-         '/opt/omero/server/OMERO.server/bin/omero')
+OMERO = ('/opt/omero/server/OMERO.server/bin/omero')
+OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 
 def test_omero_version(host):
@@ -18,3 +19,24 @@ def test_omero_version(host):
 def test_postgres_version(host):
     ver = host.check_output("psql --version")
     assert ver.startswith('psql (PostgreSQL) 9.4.')
+
+
+def test_omero_root_login(host):
+    with host.sudo('data-importer'):
+        host.check_output('%s login %s' % (OMERO, OMERO_LOGIN))
+
+
+@pytest.mark.parametrize("key,value", [
+    ('omero.data.dir', '/OMERO'),
+    ('omero.client.ui.tree.type_order',
+     '["screen", "plate", "project", "dataset"]'),
+    ('omero.policy.binary_access', '-read,-write,-image,-plate'),
+])
+def test_omero_server_config(host, key, value):
+    with host.sudo('omero-server'):
+        cfg = host.check_output("%s config get %s" % (OMERO, key))
+    assert cfg == value
+
+
+def test_no_virtualenv(host):
+    assert not host.file('/opt/omero/server/venv').exists

--- a/molecule/resources/tests/test_olddep.py
+++ b/molecule/resources/tests/test_olddep.py
@@ -1,13 +1,11 @@
 import os
 import re
-import pytest
 import testinfra.utils.ansible_runner
 
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-olddep')
 
 OMERO = '/opt/omero/server/OMERO.server/bin/omero'
-OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 
 def test_omero_version(host):
@@ -19,23 +17,6 @@ def test_omero_version(host):
 def test_postgres_version(host):
     ver = host.check_output("psql --version")
     assert ver.startswith('psql (PostgreSQL) 9.4.')
-
-
-def test_omero_root_login(host):
-    with host.sudo('data-importer'):
-        host.check_output('%s login %s' % (OMERO, OMERO_LOGIN))
-
-
-@pytest.mark.parametrize("key,value", [
-    ('omero.data.dir', '/OMERO'),
-    ('omero.client.ui.tree.type_order',
-     '["screen", "plate", "project", "dataset"]'),
-    ('omero.policy.binary_access', '-read,-write,-image,-plate'),
-])
-def test_omero_server_config(host, key, value):
-    with host.sudo('omero-server'):
-        cfg = host.check_output("%s config get %s" % (OMERO, key))
-    assert cfg == value
 
 
 def test_no_virtualenv(host):

--- a/molecule/resources/tests/test_olddep.py
+++ b/molecule/resources/tests/test_olddep.py
@@ -6,7 +6,7 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-server-olddep')
 
-OMERO = ('/opt/omero/server/OMERO.server/bin/omero')
+OMERO = '/opt/omero/server/OMERO.server/bin/omero'
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 

--- a/molecule/upgradetovenv/Dockerfile.j2
+++ b/molecule/upgradetovenv/Dockerfile.j2
@@ -1,0 +1,1 @@
+../resources/Dockerfile.j2

--- a/molecule/upgradetovenv/molecule.yml
+++ b/molecule/upgradetovenv/molecule.yml
@@ -1,0 +1,57 @@
+---
+dependency:
+  name: galaxy
+  options:
+    role-file: molecule/resources/requirements.yml
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: omero-server-upgradetovenv
+    image: centos/systemd
+    image_version: latest
+    command: /sbin/init
+    privileged: true
+    groups:
+      - docker-hosts
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+  # - Install OMERO without a virtualenv in the prepare step
+  # - Swtich to a virtualenv in the converge step
+  options:
+    v: true
+    diff: true
+    # tags: [x]
+  playbooks:
+    prepare: ../resources/install-novenv.yml
+    converge: ../resources/upgrade-omero.yml
+  inventory:
+    host_vars:
+      omero-server-upgradetovenv:
+        omero_server_ice_version: "3.6"
+        omero_server_release: latest
+        omero_server_python_addons:
+          - omero-upload
+        omero_server_virtualenv: true
+        postgresql_version: "9.6"
+        ice_python_wheel: >-
+          https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
+    group_vars:
+      docker-hosts:
+        omero_server_systemd_require_network: false
+scenario:
+  name: upgradetovenv
+  create_sequence:
+    - dependency
+    - create
+    - prepare
+  converge_sequence:
+    - converge
+verifier:
+  name: testinfra
+  directory: ../resources/tests/
+  lint:
+    name: flake8

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -169,3 +169,15 @@
   notify:
     - omero-server rewrite omero-server configuration
     - omero-server restart omero-server
+
+- name: omero server | patch bin/omero to use virtualenv
+  become: true
+  replace:
+    mode: 0755
+    path: "{{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero"
+    regexp: "^#!.+python$"
+    replace: "#!{{ omero_server_basedir }}/venv/bin/python"
+  when: omero_server_virtualenv
+  notify:
+    - omero-server rewrite omero-server configuration
+    - omero-server restart omero-server

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -7,16 +7,23 @@
     path: "{{ omero_server_basedir }}/{{ omero_server_symlink }}"
   register: omero_server_symlink_st
 
+- name: omero server | is virtualenv present
+  become: true
+  stat:
+    path: "{{ omero_server_basedir }}/venv"
+  register: omero_server_venv_st
+
 # This should be safe to always run including in check-mode
 - name: omero server | get server version
   become: true
   become_user: "{{ omero_server_system_user }}"
   command: >-
-    {{ omero_server_basedir }}/venv/bin/python
-    {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero
+    {{ omero_server_omero_command }}
     version
   register: omero_server_version
-  when: omero_server_symlink_st.stat.exists
+  when: >-
+    omero_server_symlink_st.stat.exists and
+    (omero_server_venv_st.stat.exists or not omero_server_virtualenv)
   changed_when: false
   check_mode: false
   # Set a custom error message
@@ -28,8 +35,14 @@
       OMERO.server found but unable to get version,
       you may have a corrupt installation
     that: >-
-      not (omero_server_symlink_st.stat.exists and
-      omero_server_version is undefined)
+      (not omero_server_virtualenv and
+        not (omero_server_symlink_st.stat.exists and
+        omero_server_version is undefined))
+      or
+      (omero_server_virtualenv and
+        not (omero_server_symlink_st.stat.exists and
+        omero_server_venv_st.stat.exists and
+        omero_server_version is undefined))
 
 # TODO: If server was started by systemd but stopped directly you may end up
 # with a hanging process
@@ -59,16 +72,22 @@
   set_fact:
     # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
     # so this should work as expected
+    # If we're switching from a non-venv to a venv treat it as an upgrade
     _omero_server_update_needed: "{{
-      omero_server_symlink_st.stat.exists and
-      (omero_server_version.stdout | version_compare(
-         _omero_server_new_version,
-         omero_server_checkupgrade_comparator))
+      (
+        (omero_server_version.stdout | default('') | length > 0) and
+        (omero_server_version.stdout | version_compare(
+          _omero_server_new_version,
+          omero_server_checkupgrade_comparator))
+      ) or (
+        omero_server_virtualenv and
+        not omero_server_venv_st.stat.exists
+      )
     }}"
 
 - debug:
     msg: >-
-      Upgrade needed: {{ omero_server_version.stdout }} ->
+      Upgrade needed: {{ omero_server_version.stdout | default('UNKNOWN') }} ->
       {{ omero_server_release }}
   when: _omero_server_update_needed
 
@@ -87,6 +106,7 @@
     state: present
     virtualenv: "{{ omero_server_basedir }}/venv"
     virtualenv_site_packages: true
+  when: omero_server_virtualenv
   notify:
     - omero-server rewrite omero-server configuration
     - omero-server restart omero-server

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -12,7 +12,9 @@
   become: true
   become_user: "{{ omero_server_system_user }}"
   command: >-
-    {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero version
+    {{ omero_server_basedir }}/venv/bin/python
+    {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero
+    version
   register: omero_server_version
   when: omero_server_symlink_st.stat.exists
   changed_when: false
@@ -77,6 +79,17 @@
       _omero_server_update_needed and
       (omero_server_release != 'present')
     }}"
+
+- name: omero server | setup virtualenv
+  become: true
+  pip:
+    name: "{{ omero_server_python_addons }}"
+    state: present
+    virtualenv: "{{ omero_server_basedir }}/venv"
+    virtualenv_site_packages: true
+  notify:
+    - omero-server rewrite omero-server configuration
+    - omero-server restart omero-server
 
 - name: omero server | install omero
   become: true

--- a/templates/omero-server-config-update-sh.j2
+++ b/templates/omero-server-config-update-sh.j2
@@ -6,5 +6,5 @@
 set -e
 
 for f in {{ omero_server_basedir }}/config/*.omero; do
-    {{ omero_server_basedir }}/venv/bin/python {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero load "$f"
+    {{ omero_server_omero_command }} load "$f"
 done

--- a/templates/omero-server-config-update-sh.j2
+++ b/templates/omero-server-config-update-sh.j2
@@ -6,5 +6,5 @@
 set -e
 
 for f in {{ omero_server_basedir }}/config/*.omero; do
-    {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero load "$f"
+    {{ omero_server_basedir }}/venv/bin/python {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero load "$f"
 done

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -24,10 +24,12 @@ Restart=no
 RestartSec=10
 # Allow up to 5 min for start/stop
 TimeoutSec=300
+{% if omero_server_virtualenv %}
 Environment="PATH={{ omero_server_basedir }}/venv/bin:/bin:/usr/bin"
+{% endif %}
 ExecStartPre={{ omero_server_basedir }}/config/omero-server-config-update.sh
-ExecStart={{ omero_server_basedir }}/venv/bin/python {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero admin start
-ExecStop={{ omero_server_basedir }}/venv/bin/python {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero admin stop
+ExecStart={{ omero_server_omero_command }} admin start
+ExecStop={{ omero_server_omero_command }} admin stop
 {% if omero_server_systemd_limit_nofile %}
 LimitNOFILE={{ omero_server_systemd_limit_nofile }}
 {% endif %}

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -24,9 +24,10 @@ Restart=no
 RestartSec=10
 # Allow up to 5 min for start/stop
 TimeoutSec=300
+Environment="PATH={{ omero_server_basedir }}/venv/bin:/bin:/usr/bin"
 ExecStartPre={{ omero_server_basedir }}/config/omero-server-config-update.sh
-ExecStart={{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero admin start
-ExecStop={{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero admin stop
+ExecStart={{ omero_server_basedir }}/venv/bin/python {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero admin start
+ExecStop={{ omero_server_basedir }}/venv/bin/python {{ omero_server_basedir }}/{{ omero_server_symlink }}/bin/omero admin stop
 {% if omero_server_systemd_limit_nofile %}
 LimitNOFILE={{ omero_server_systemd_limit_nofile }}
 {% endif %}


### PR DESCRIPTION
Installs and runs OMERO.server from a virtualenv `/opt/omero/server/venv`
New parameter `omero_server_python_addons` that can be used to install addons at the same time, though it's also fine to install addons into the virtualenv separately.

# Updated 26 Aug:
Default behaviour is unchanged (no virtualenv) though we should consider switching this as we start encouraging people to install decoupled components.

Includes a `no-venv → venv` test.