### PR TITLE
 Fix Ansible version_compare change in behaviour

### DIFF
--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -70,13 +70,15 @@
 
 - name: omero server | checkupgrade
   set_fact:
-    # Experimentation shows "5.3.2 | version_compare('latest', '<')" is False
-    # so this should work as expected
+    # If _omero_server_new_version does not begin with a number assume it's a
+    # custom build, always upgrade
     # If we're switching from a non-venv to a venv treat it as an upgrade
     _omero_server_update_needed: "{{
       (
+        not (_omero_server_new_version | regex_search('^[0-9]'))
+      ) or (
         (omero_server_version.stdout | default('') | length > 0) and
-        (omero_server_version.stdout | version_compare(
+        (omero_server_version.stdout is version_compare(
           _omero_server_new_version,
           omero_server_checkupgrade_comparator))
       ) or (


### PR DESCRIPTION
Non-standard strings (e.g. CI job names) can no longer be compared against versions. Since this usually indicates a CI build unconditionanally upgrade.

Also fixes a deprecation warning:
[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using
`result|version_compare` use `result is version_compare`. This feature will be
removed in version 2.9. Deprecation warnings can be disabled by setting
deprecation_warnings=False in ansible.cfg.