### PR TITLE
Re-create bin directory for omero wrapper

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,9 +12,6 @@ omero_server_virtualenv: false
 # Python 3?
 omero_server_python3: false
 
-# Make bin/omero a wrapper script for the virtualenv omero
-omero_server_python3_replace_omero: true
-
 # OMERO database connection parameters
 omero_server_dbhost: localhost
 omero_server_dbuser: omero

--- a/molecule/resources/playbook-py3.yml
+++ b/molecule/resources/playbook-py3.yml
@@ -24,7 +24,7 @@
           - project
           - dataset
       omero_server_python3: true
-      omero_server_release: 5.6.0-m4
+      omero_server_release: 5.6.0-rc1
       omero_server_python_addons:
         - omero-upload
 

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -224,28 +224,22 @@
     state: absent
   when: omero_server_python3
 
-- name: omero server | patch bin/omero to use virtualenv
-  become: true
-  replace:
-    mode: 0755
-    path: "{{ omero_server_omero_command }}"
-    regexp: "^#!.+python$"
-    replace: "#!{{ omero_server_virtualenv_basedir }}/bin/python"
-  when: >-
-    (not omero_server_python3 and omero_server_virtualenv) or
-    (omero_server_python3 and not omero_server_python3_replace_omero)
-  notify:
-    - omero-server rewrite omero-server configuration
-    - omero-server restart omero-server
-
 # Remembering to set OMERODIR everywhere is prone to error
+- name: omero server | create bin directory for wrapper
+  become: true
+  file:
+    path: "{{ omero_server_omerodir }}/bin/"
+    state: directory
+    mode: 0555
+  when: omero_server_python3
+
 - name: omero server | create omero server wrapper
   become: true
   template:
     dest: "{{ omero_server_omero_command }}"
     src: bin-omero.j2
     mode: 0555
-  when: omero_server_python3 and omero_server_python3_replace_omero
+  when: omero_server_python3
   notify:
     - omero-server rewrite omero-server configuration
     - omero-server restart omero-server


### PR DESCRIPTION
As a result of https://github.com/ome/openmicroscopy/pull/6200,
the bin directory is no longer being created leading to a build
failure in https://github.com/ome/omero-server-docker/pull/41