### PR TITLE
Add omero_server_systemd_environment to systemd service

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ OMERO.server systemd configuration.
 - `omero_server_systemd_require_network`: Should omero systemd services require a network before starting? Default `True`.
 - `omero_server_systemd_after`: A list of strings with additional service names to appear in systemd unit file "After" statements. Default empty/none.
 - `omero_server_systemd_requires`: A list of strings with additional service names to appear in systemd unit file "Requires" statements. Default empty/none.
+- `omero_server_systemd_environment`: Dictionary of additional environment variables.
 
 Python virtualenv
 - `omero_server_virtualenv`: Use a virtualenv for most OMERO.server dependencies, ignored on Python 3 (a virtualenv is always used).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,9 @@ omero_server_systemd_after: []
 # Services which OMERO server needs to be concurrently running.
 omero_server_systemd_requires: []
 
+# Dictionary of additional environment variables
+omero_server_systemd_environment: {}
+
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []
 

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -29,6 +29,9 @@ TimeoutSec=300
 {% if omero_server_virtualenv and not omero_server_python3 %}
 Environment="PATH={{ omero_server_basedir }}/venv/bin:/bin:/usr/bin"
 {% endif %}
+{% for name in (omero_server_systemd_environment | sort) %}
+Environment={{ name }}={{ omero_server_systemd_environment[name] | quote }}
+{% endfor %}
 ExecStartPre={{ omero_server_config_update }}
 ExecStart={{ omero_server_omero_command }} admin start
 ExecStop={{ omero_server_omero_command }} admin stop


### PR DESCRIPTION
Enables arbitrary extra environment variables to be set when running OMERO.server with systemd.

This is an attempt to workaround https://github.com/ome/omero-web/issues/118