### PR TITLE
Use ome.postgresql_client

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Example Playbooks
       roles:
 
       - role: ome.postgresql
-        postgresql_install_server: True
         postgresql_version: "10"
         postgresql_databases:
           - name: omero

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Example Playbooks
 
       - role: ome.postgresql
         postgresql_install_server: True
+        postgresql_version: "10"
         postgresql_databases:
           - name: omero
         postgresql_users:
@@ -103,7 +104,7 @@ Example Playbooks
       - role: ome.omero-server
 
 
-    # Install or upgrade to a particular version, use an external database
+    # Install or upgrade to a particular version, with an external database
     - hosts: localhost
       roles:
       - ome.omero-server
@@ -112,6 +113,8 @@ Example Playbooks
         omero_server_dbuser: db_user
         omero_server_dbname: db_name
         omero_server_dbpassword: db_password
+        # Version required for the psql client
+        postgresql_version: "10"
 
 
 Author Information

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -25,6 +25,4 @@ dependencies:
       ice_version: "{{ omero_server_ice_version }}"
       ice_install_devel: "{{ not omero_server_python3 }}"
       ice_install_python: "{{ not omero_server_python3 }}"
-  - role: ome.postgresql
-    vars:
-      postgresql_install_server: false
+  - role: ome.postgresql_client

--- a/molecule/resources/install-novenv.yml
+++ b/molecule/resources/install-novenv.yml
@@ -5,7 +5,6 @@
   roles:
 
     - role: ome.postgresql
-      postgresql_install_server: true
       postgresql_databases:
         - name: omero
       postgresql_users:

--- a/molecule/resources/install-oldomero.yml
+++ b/molecule/resources/install-oldomero.yml
@@ -5,7 +5,6 @@
   roles:
 
     - role: ome.postgresql
-      postgresql_install_server: true
       postgresql_databases:
         - name: omero
       postgresql_users:

--- a/molecule/resources/playbook-py3.yml
+++ b/molecule/resources/playbook-py3.yml
@@ -6,7 +6,6 @@
   roles:
 
     - role: ome.postgresql
-      postgresql_install_server: true
       postgresql_databases:
         - name: omero
       postgresql_users:

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -6,3 +6,4 @@
 - src: ome.omero_python_deps
 - src: ome.ice
 - src: ome.postgresql
+- src: ome.postgresql_client


### PR DESCRIPTION
Uses the new `ome.postgresql_client` instead of overriding `postgresql_install_server` in `ome.postgresql`

Tag: Not sure, maybe `3.2.0`, I don't think it's a breaking change.

This should be released before https://github.com/ome/ansible-role-postgresql/pull/19 is released to avoid errors for anyone who hasn't pinned their roles to a fixed version. This is due to the removal of `postgresql_install_server: False` (`postgresql_install_server: True` is no-op).