### PR TITLE
Do not pin OMERO.server version to 5.6.0-rc1 in Molecule

### DIFF
--- a/molecule/resources/playbook-py3.yml
+++ b/molecule/resources/playbook-py3.yml
@@ -22,6 +22,7 @@
           - plate
           - project
           - dataset
+      omero_server_release: latest
       omero_server_python_addons:
         - omero-upload
 

--- a/molecule/resources/playbook-py3.yml
+++ b/molecule/resources/playbook-py3.yml
@@ -22,8 +22,6 @@
           - plate
           - project
           - dataset
-      # TODO: Delete (default to latest)
-      omero_server_release: 5.6.0-rc1
       omero_server_python_addons:
         - omero-upload
 


### PR DESCRIPTION
Try removing the hardcoded pinning to a release candidate version of the server in one of the Molecule tests