### PR TITLE
Remove omero_server_systemd_require_network

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ You may need to change these for in-place imports.
 OMERO.server systemd configuration.
 - `omero_server_systemd_setup`: Create and start the `omero-server` systemd service, default `True`
 - `omero_server_systemd_limit_nofile`: Systemd limit for number of open files (default ignore)
-- `omero_server_systemd_require_network`: Should omero systemd services require a network before starting? Default `True`.
 - `omero_server_systemd_after`: A list of strings with additional service names to appear in systemd unit file "After" statements. Default empty/none.
 - `omero_server_systemd_requires`: A list of strings with additional service names to appear in systemd unit file "Requires" statements. Default empty/none.
 - `omero_server_systemd_environment`: Dictionary of additional environment variables.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,9 +52,6 @@ omero_server_systemd_setup: true
 # Change the systemd limit for number of open files (default ignore)
 omero_server_systemd_limit_nofile:
 
-# Should omero systemd services require a network?
-omero_server_systemd_require_network: true
-
 # Services which OMERO server needs to be running before it can start,
 # such as remote storage.
 omero_server_systemd_after: []

--- a/molecule/newdep/molecule.yml
+++ b/molecule/newdep/molecule.yml
@@ -38,9 +38,6 @@ provisioner:
         postgresql_version: "9.6"
         ice_python_wheel: >-
           https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
-    group_vars:
-      docker-hosts:
-        omero_server_systemd_require_network: false
 scenario:
   name: newdep
 verifier:

--- a/molecule/python3/molecule.yml
+++ b/molecule/python3/molecule.yml
@@ -34,9 +34,6 @@ provisioner:
     host_vars:
       omero-server-python3:
         postgresql_version: "10"
-    group_vars:
-      docker-hosts:
-        omero_server_systemd_require_network: false
 scenario:
   name: python3
   converge_sequence:

--- a/molecule/upgrade-py2py3/molecule.yml
+++ b/molecule/upgrade-py2py3/molecule.yml
@@ -32,9 +32,6 @@ provisioner:
     host_vars:
       omero-server-py2py3:
         postgresql_version: "10"
-    group_vars:
-      docker-hosts:
-        omero_server_systemd_require_network: false
 scenario:
   name: upgrade-py2py3
   converge_sequence:

--- a/molecule/upgradetovenv/molecule.yml
+++ b/molecule/upgradetovenv/molecule.yml
@@ -39,9 +39,6 @@ provisioner:
         postgresql_version: "9.6"
         ice_python_wheel: >-
           https://github.com/openmicroscopy/zeroc-ice-py-centos7/releases/download/0.1.0/zeroc_ice-3.6.4-cp27-cp27mu-linux_x86_64.whl
-    group_vars:
-      docker-hosts:
-        omero_server_systemd_require_network: false
 scenario:
   name: upgradetovenv
   create_sequence:

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -8,9 +8,6 @@ After=postgresql-9.5.service
 After=postgresql-9.6.service
 After=postgresql-10.service
 After=postgresql-11.service
-{% if omero_server_systemd_require_network %}
-Requires=network.service
-{% endif %}
 After=network.service
 {% for value in omero_server_systemd_after %}After={{ value }}
 {% endfor %}


### PR DESCRIPTION
Many OSes are moving away from the network.service scripts, so we shouldn't require it, especially since this still has "After=network.service" which means start after the network.service if it's enabled, otherwise ignore.

I'm undecided on whether this can go in alongside https://github.com/ome/ansible-role-omero-server/pull/50 which is an example of a distribution that uses an alternative to `network.service` since it shouldn't break existing deployments (since `After=network.service` is kept) or whether it counts as a breaking change.