### PR TITLE
CentOS 7: configure omero-certificates

### DIFF
--- a/molecule/centos7/molecule.yml
+++ b/molecule/centos7/molecule.yml
@@ -34,6 +34,7 @@ provisioner:
     host_vars:
       omero-server-centos7:
         postgresql_version: "11"
+        omero_server_selfsigned_certificates: true
 scenario:
   name: centos7
   converge_sequence:

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -218,7 +218,7 @@
     - omero-server restart omero-server
 
 - name: system packages | install openssl
-  become: yes
+  become: true
   package:
     name: openssl
     state: present

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -216,3 +216,9 @@
   notify:
     - omero-server rewrite omero-server configuration
     - omero-server restart omero-server
+
+- name: system packages | install openssl
+  become: yes
+  package:
+    name: openssl
+    state: present


### PR DESCRIPTION
Fixes https://github.com/ome/ansible-role-omero-server/issues/57

As a result of TLS 1.0/1.1 being now disabled by default in OpenJDK incl. 8 and 11, all base CentOS 7 installations start failing import with a `SSLHandshakeException`.

This PR configures `omero-certificates` to generate self-signed certificates exactly like what is currently done in Ubuntu 18.04 and Ubuntu 20.04. This seems to be sufficient to fix the failing import tests.

Note 900548e ensures `openssl` is installed on the system but I suspect we might want to push this installation down to [ome.basedeps](https://github.com/ome/ansible-role-basedeps). Opening this PR as it is anyways to start the discussion