### PR TITLE
Add /usr/local/bin executable

### DIFF
--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -8,7 +8,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 
 # Ubuntu sudo doesn't set HOME so it tries to write to /root
 ENV = 'OMERO_USERDIR=/home/data-importer/omero-{}'.format(time())
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = '/usr/local/bin/omero'
 OMERO_LOGIN = '-C -s localhost -u root -w omero'
 
 

--- a/molecule/resources/tests/test_python3.py
+++ b/molecule/resources/tests/test_python3.py
@@ -5,7 +5,7 @@ import testinfra.utils.ansible_runner
 testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('omero-py3')
 
-OMERO = '/opt/omero/server/OMERO.server/bin/omero'
+OMERO = "/usr/local/bin/omero"
 # Need to match 5.6.dev2
 # VERSION_PATTERN = re.compile('(\d+)\.(\d+)\.(\d+)-ice36-')
 VERSION_PATTERN = re.compile(r'(\d+)\.(\d+)\.(\w+)')

--- a/tasks/omero-install.yml
+++ b/tasks/omero-install.yml
@@ -217,6 +217,13 @@
     - omero-server rewrite omero-server configuration
     - omero-server restart omero-server
 
+- name: omero server | create /usr/local/bin symlink
+  become: true
+  file:
+    src: "{{ omero_server_omero_command }}"
+    dest: /usr/local/bin/omero
+    state: link
+
 - name: system packages | install openssl
   become: true
   package:


### PR DESCRIPTION
Fixes #59

Adds a task creating an `/usr/local/bin/omero` executable (symlinking to `/opt/omero/server/OMERO.server/bin/omero`) and update the Molecule tests to use this executable.

For bash environment, this means that on an OMERO.server system provisioned by Ansible, the following commands should just work out of the box for any user (i.e. without the path prefixing)

```
omero login
omero import
```