### PR TITLE
simplify installation of omero-cli-server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -110,7 +110,7 @@ omero_server_python_requirements:
   - jinja2
   # Includes optional dependencies: always installed but activation may be
   # optional
-  - 'omero-server[default]==0.1.0'
+  - omero-server
 
 # Path to virtualenv
 omero_server_virtualenv_basedir: "{{ omero_server_basedir + '/venv3' }}"


### PR DESCRIPTION
The tables are installed by default since the removal of Ubuntu 16.04 support
