### PR TITLE
Modify default variables to install self-signed certificates by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ You may need to change these for in-place imports.
 - `omero_server_datadir_managedrepo_mode`: Permissions for OMERO `ManagedRepository`
 - `omero_server_datadir`: OMERO data directory, default `/OMERO`
 - `omero_server_datadir_managedrepo`: OMERO ManagedRepository directory
-- `omero_server_selfsigned_certificates`: Generate self-signed certificates instead of using anonymous ciphers, default `False`, use this if your system does not support insecure ciphers
+- `omero_server_selfsigned_certificates`: Generate self-signed certificates instead of using anonymous ciphers, default `True`, use this if your system does not support insecure ciphers
 
 OMERO.server systemd configuration.
 - `omero_server_systemd_setup`: Create and start the `omero-server` systemd service, default `True`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -64,7 +64,7 @@ omero_server_python_addons: []
 omero_server_database_backupdir: ""
 
 # If true disable anonymous ciphers and use self-signed certificates
-omero_server_selfsigned_certificates: false
+omero_server_selfsigned_certificates: true
 
 
 ######################################################################


### PR DESCRIPTION
Recent changes to OMERO.py removing the ADH ciphers combined with increased security requirements on modern platforms means that an OMERO.server without self-signed certificates is unlikely to be able to function correctly.
This changes proposes to set the default value of the internal variable to true so that certificates are generated automatically on startup.