### PR TITLE
Fix include 

### DIFF
--- a/meta/requirements.yml
+++ b/meta/requirements.yml
@@ -4,5 +4,4 @@
 - src: ome.java
 - src: ome.python3_virtualenv
 - src: ome.ice
-- src: ome.postgresql
 - src: ome.postgresql_client

--- a/tasks/pre-tasks.yml
+++ b/tasks/pre-tasks.yml
@@ -28,7 +28,3 @@
 - name: omero server | Include ome.postgresql_client
   include_role:
     name: ome.postgresql_client
-
-- name: omero server | Include ome.postgresql
-  include_role:
-    name: ome.postgresql


### PR DESCRIPTION
This PR removes include `PostgreSQL `role. It is redundant and needed only for molecular tests so, it should not included in the `requirements.yml` inside `meta` folded or pre-task.yml inside `tasks`.
This was one of the causes of the Rokcylinux image-building failure.
I have pushed it to the `ansible-galaxy`, i.e.  `khaledk2.omero_server`.
I have created a branch on my omero-server-docker fork (https://github.com/khaledk2/omero-server-docker/tree/build_rocky9)  based on https://github.com/jburel/omero-server-docker/tree/ubuntu22.04, I have used the modified omero-server-role and made the required modifications to make it build the RockyLinux 9 image.
It has built the image successfully and passed the tests on: 
https://github.com/khaledk2/omero-server-docker/actions/runs/6922804692

cc @jburel @sbesson @pwalczysko 
