### PR TITLE
Aarch64 (WIP)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -75,8 +75,7 @@ omero_server_ice_version: "3.6"
 
 omero_server_python_requirements_ice_package:
   RedHat:
-    9: "https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/\
-      20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl"
+    9: "https://downloads.openmicroscopy.org/ice/zeroc_ice-3.6.5-cp39-cp39-linux_aarch64.whl"
   Debian:
     22: "https://downloads.openmicroscopy.org/ice/zeroc_ice-3.6.5-cp39-cp39-linux_aarch64.whl"
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -78,8 +78,7 @@ omero_server_python_requirements_ice_package:
     9: "https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/\
       20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl"
   Debian:
-    22: "https://github.com/glencoesoftware/zeroc-ice-py-ubuntu2204-x86_64/releases/download/\
-      20221004/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl"
+    22: "https://downloads.openmicroscopy.org/ice/zeroc_ice-3.6.5-cp39-cp39-linux_aarch64.whl"
 
 
 # TODO: sort this out


### PR DESCRIPTION
With a hand-built wheel, this can progress to the next failure:

```
202.5     "stderr": "Traceback (most recent call last):\n  File \"/opt/omero/server/venv3/bin/omero\", line 5, in <module>\n    from omero.main import main\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omero/__init__.py\", line 15, in <module>\n    import Ice\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/Ice.py\", line 47, in <module>\n    import IcePy\nImportError: libssl.so.1.1: cannot open shared object file: No such file or directory\n2023-12-06 14:10:45,620 [omego.extern] ERROR Failed [0.016 s]\nTraceback (most recent call last):\n  File \"/opt/omero/server/venv3/bin/omego\", line 33, in <module>\n    sys.exit(load_entry_point('omego==0.7.0', 'console_scripts', 'omego')())\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/main.py\", line 48, in entry_point\n    main(\"omego\", items=[\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/yaclifw/framework.py\", line 188, in main\n    ns.func(ns)\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/upgrade.py\", line 534, in __call__\n    UnixInstall(self.NAME, args)\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/upgrade.py\", line 63, in __init__\n    self.external.setup_omero_cli(args.omerocli)\n  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/external.py\", line 159, in setup_omero_cli\n    raise Exception('Unable to execute omero executable')\nException: Unable to execute omero executable",
202.5     "stderr_lines": [
202.5         "Traceback (most recent call last):",
202.5         "  File \"/opt/omero/server/venv3/bin/omero\", line 5, in <module>",
202.5         "    from omero.main import main",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omero/__init__.py\", line 15, in <module>",
202.5         "    import Ice",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/Ice.py\", line 47, in <module>",
202.5         "    import IcePy",
202.5         "ImportError: libssl.so.1.1: cannot open shared object file: No such file or directory",
202.5         "2023-12-06 14:10:45,620 [omego.extern] ERROR Failed [0.016 s]",
202.5         "Traceback (most recent call last):",
202.5         "  File \"/opt/omero/server/venv3/bin/omego\", line 33, in <module>",
202.5         "    sys.exit(load_entry_point('omego==0.7.0', 'console_scripts', 'omego')())",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/main.py\", line 48, in entry_point",
202.5         "    main(\"omego\", items=[",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/yaclifw/framework.py\", line 188, in main",
202.5         "    ns.func(ns)",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/upgrade.py\", line 534, in __call__",
202.5         "    UnixInstall(self.NAME, args)",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/upgrade.py\", line 63, in __init__",
202.5         "    self.external.setup_omero_cli(args.omerocli)",
202.5         "  File \"/opt/omero/server/venv3/lib64/python3.9/site-packages/omego/external.py\", line 159, in setup_omero_cli",
202.5         "    raise Exception('Unable to execute omero executable')",
202.5         "Exception: Unable to execute omero executable"
202.5     ],
202.5     "stdout": "",
202.5     "stdout_lines": []
202.5 }
202.5
202.5 PLAY RECAP *********************************************************************
202.5 localhost                  : ok=52   changed=27   unreachable=0    failed=1    skipped=29   rescued=0    ignored=0
```

cc: @khaledk2 