### PR TITLE
WiP: Python version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,7 @@ omero_server_systemd_environment: {}
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []
 
-omero_server_python_version: "310"
+omero_server_python_version: "312"
 
 # If non-empty dump the OMERO database to this directory before upgrading
 omero_server_database_backupdir: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,7 @@ omero_server_systemd_environment: {}
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []
 
-omero_server_python_version: "312"
+omero_server_python_version: "311"
 
 # If non-empty dump the OMERO database to this directory before upgrading
 omero_server_database_backupdir: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,6 +60,8 @@ omero_server_systemd_environment: {}
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []
 
+omero_server_python_version: "312"
+
 # If non-empty dump the OMERO database to this directory before upgrading
 omero_server_database_backupdir: ""
 
@@ -74,12 +76,14 @@ omero_server_selfsigned_certificates: true
 omero_server_ice_version: "3.6"
 
 omero_server_python_requirements_ice_package:
+
   RedHat:
-    9: "https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/\
-      20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl"
+    9: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp{{ omero_server_python_version }}-cp{{ omero_server_python_version }}-manylinux_2_28_x86_64.whl"
+
   Debian:
-    22: "https://github.com/glencoesoftware/zeroc-ice-py-ubuntu2204-x86_64/releases/download/\
-      20221004/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl"
+    22: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp{{ omero_server_python_version }}-cp{{ omero_server_python_version }}-manylinux_2_28_x86_64.whl"
+
+    24: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp{{ omero_server_python_version }}-cp{{ omero_server_python_version }}-manylinux_2_28_x86_64.whl"
 
 
 # TODO: sort this out

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,7 +60,7 @@ omero_server_systemd_environment: {}
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []
 
-omero_server_python_version: "312"
+omero_server_python_version: "310"
 
 # If non-empty dump the OMERO database to this directory before upgrading
 omero_server_database_backupdir: ""


### PR DESCRIPTION
@jburel @khaledk2 

As discussed, adding a new variable for the python version into the role.

The ice wheel variable had to be adjusted too.

The problem seems to be though the compatibility of the wheels with the platform.
From https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/tag/20240202.
python:
310 works on Ubuntu 22.04, but not Rocky Linux 
311 and 312 work on neither 

Not sure why the platform is reported as not being compatible with those wheels.