### PR TITLE
Add new systemd service variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,9 @@ omero_server_systemd_requires: []
 # Dictionary of additional environment variables
 omero_server_systemd_environment: {}
 
+# Dictionary of additional service variables
+omero_additional_server_systemd_vars: {}
+
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []
 

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -26,6 +26,10 @@
       omero_server_release: latest
       omero_server_python_addons:
         - omero-upload
+      omero_additional_server_systemd_vars:
+        Restart: on-failure
+        StartLimitIntervalSec: 600
+        StartLimitBurst: 5
 
   tasks:
 

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -74,3 +74,10 @@ def test_inplace_import(host):
     f = host.file('/OMERO/ManagedRepository/%s' % outhql.split(',', 1)[1])
     assert f.is_symlink
     assert f.linked_to == fake_file
+
+# test for omero_additional_web_systemd_vars new var
+def test_omero_server_service_config(host):
+    serv_cfg = host.check_output("cat /etc/systemd/system/omero-server.service")
+    assert 'StartLimitIntervalSec=600' in serv_cfg
+    assert 'StartLimitBurst=5' in serv_cfg
+    assert 'Restart=on-failure' in serv_cfg

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -32,6 +32,9 @@ ExecStop={{ omero_server_omero_command }} admin stop
 {% if omero_server_systemd_limit_nofile %}
 LimitNOFILE={{ omero_server_systemd_limit_nofile }}
 {% endif %}
+{% for name in (omero_additional_server_systemd_vars | sort) %}
+{{ name }}={{ omero_additional_server_systemd_vars[name] | quote }}
+{% endfor %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a configurable variable, i.e. `omero_additional_server_systemd_vars`, to extend the service section of a service definition file, i.e. `omero-server.service`, giving users more flexibility.