### PR TITLE
Fix service warnning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,10 +57,10 @@ omero_server_systemd_requires: []
 # Dictionary of additional environment variables
 omero_server_systemd_environment: {}
 
-# Dictionary of additional service variables
+# Dictionary of additional service variables (service part)
 omero_additional_server_systemd_service_vars: {}
 
-# Dictionary of additional unit variables
+# Dictionary of additional service variables (unit part)
 omero_additional_server_systemd_unit_vars: {}
 
 # List of additional Python packages to be installed into virtualenv

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -58,7 +58,10 @@ omero_server_systemd_requires: []
 omero_server_systemd_environment: {}
 
 # Dictionary of additional service variables
-omero_additional_server_systemd_vars: {}
+omero_additional_server_systemd_service_vars: {}
+
+# Dictionary of additional unit variables
+omero_additional_server_systemd_unit_vars: {}
 
 # List of additional Python packages to be installed into virtualenv
 omero_server_python_addons: []

--- a/molecule/resources/playbook.yml
+++ b/molecule/resources/playbook.yml
@@ -26,8 +26,9 @@
       omero_server_release: latest
       omero_server_python_addons:
         - omero-upload
-      omero_additional_server_systemd_vars:
+      omero_additional_server_systemd_service_vars:
         Restart: on-failure
+      omero_additional_server_systemd_unit_vars:
         StartLimitIntervalSec: 600
         StartLimitBurst: 5
 

--- a/molecule/resources/tests/test_default.py
+++ b/molecule/resources/tests/test_default.py
@@ -81,3 +81,8 @@ def test_omero_server_service_config(host):
     assert 'StartLimitIntervalSec=600' in serv_cfg
     assert 'StartLimitBurst=5' in serv_cfg
     assert 'Restart=on-failure' in serv_cfg
+
+# test for the correctness of the service variables
+def test_omero_server_service_config(host):
+    serv_ana = host.check_output("systemd-analyze verify omero-server.service")
+    assert 'Unknown key name' not in serv_ana

--- a/templates/systemd-system-omero-server-service.j2
+++ b/templates/systemd-system-omero-server-service.j2
@@ -13,6 +13,9 @@ After=network.service
 {% endfor %}
 {% for value in omero_server_systemd_requires %}Requires={{ value }}
 {% endfor %}
+{% for name in (omero_additional_server_systemd_unit_vars | sort) %}
+{{ name }}={{ omero_additional_server_systemd_unit_vars[name] | quote }}
+{% endfor %}
 
 [Service]
 User={{ omero_server_system_user }}
@@ -32,8 +35,8 @@ ExecStop={{ omero_server_omero_command }} admin stop
 {% if omero_server_systemd_limit_nofile %}
 LimitNOFILE={{ omero_server_systemd_limit_nofile }}
 {% endif %}
-{% for name in (omero_additional_server_systemd_vars | sort) %}
-{{ name }}={{ omero_additional_server_systemd_vars[name] | quote }}
+{% for name in (omero_additional_server_systemd_service_vars | sort) %}
+{{ name }}={{ omero_additional_server_systemd_service_vars[name] | quote }}
 {% endfor %}
 
 [Install]


### PR DESCRIPTION
This PR fixes this issue :

https://github.com/ome/ansible-role-omero-server/pull/89#issuecomment-4489677069

It adds two vars instead of one, one to be added to the `unit `and the other to be added to the `service `section in the service file.
In addition has added a test unit to validate the vars.

@pwalczysko 