### PR TITLE
Fix workflow and PostgreSQL server install issue

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.12'
+          python-version: '3.11'
       - name: Install Ansible & Molecule
         run: |
             pip install "requests" "ansible" "ansible-lint" "flake8"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -36,7 +36,8 @@ jobs:
       - name: Install Ansible & Molecule
         run: |
             pip install "requests" "ansible==13.7.0" "ansible-lint" "flake8"
-            pip install "molecule" "ansible-compat"
+            pip install "molecule" 
+            pip install "ansible-core>=2.20.6"
             pip install molecule-plugins[docker] pytest-testinfra
       - name: Run molecule
         run: molecule test -s "${{ matrix.scenario }}"

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -32,10 +32,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install Ansible & Molecule
         run: |
-            pip install "requests" "ansible" "ansible-lint" "flake8"
+            pip install "requests" "ansible==13.7.0" "ansible-lint" "flake8"
             pip install "molecule" "ansible-compat"
             pip install molecule-plugins[docker] pytest-testinfra
       - name: Run molecule

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - id: listscenarios
         uses: ome/action-ansible-molecule-list-scenarios@main
 
@@ -29,8 +29,8 @@ jobs:
       matrix:
         scenario: ${{fromJson(needs.list-scenarios.outputs.matrix)}}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
       - name: Install Ansible & Molecule

--- a/molecule/resources/requirements.yml
+++ b/molecule/resources/requirements.yml
@@ -5,5 +5,7 @@
 - src: ome.java
 - src: ome.python3_virtualenv
 - src: ome.ice
-- src: ome.postgresql
+- name: ome.postgresql
+  src: "https://github.com/khaledk2/ansible-role-postgresql"
+  version: "fix_workflow_rhel_inst"
 - src: ome.postgresql_client


### PR DESCRIPTION
This PR fixes the failing workflow action. 
A dependency incompatibility with Python 3.12 caused the action run failure, so the workflow has been updated to install ansible==13.7.0, which resolves the error.

Additionally, the test failed due to a recent change to the PostgreSQL download URL. The test has been updated to use the `ansible-role-postgresql` PR, which fixes this issue (https://github.com/ome/ansible-role-postgresql/pull/45).
