### PR TITLE
Fixing syntax of molecule yml

### DIFF
--- a/molecule/rockylinux9/molecule.yml
+++ b/molecule/rockylinux9/molecule.yml
@@ -12,7 +12,7 @@ lint: |
 platforms:
   - name: omero-server-rockylinux9
     image: eniocarboni/docker-rockylinux-systemd:9
-    image_version: latest
+    # image_version: latest
     command: /sbin/init
     privileged: true
     cgroupns_mode: host


### PR DESCRIPTION
Since the weekend, the molecule test was failing on Rockylinux. See https://github.com/ome/ansible-role-omero-server/actions/runs/29706099303.

The problem is that the new Molecule 26 is expecting a slightly different syntax of the ``molecule/rockylinux9/molecule.yml``

The solution was:

Remove ``image_version`` tag - invalid in molecule 26

cc @khaledk2 